### PR TITLE
Allow replication of content moderation data

### DIFF
--- a/modules/contentpool_normalization/src/EventSubscriber/ContentpoolNormalizationEventSubscriber.php
+++ b/modules/contentpool_normalization/src/EventSubscriber/ContentpoolNormalizationEventSubscriber.php
@@ -108,10 +108,6 @@ class ContentpoolNormalizationEventSubscriber implements EventSubscriberInterfac
     foreach ($language_keys as $key) {
       // Remove path alias information from all entities.
       unset($normalized[$key]['path']);
-      // Do not replicate moderation_state - only the status flag.
-      unset($normalized[$key]['moderation_state']);
-      unset($normalized[$key]['publish_state']);
-      unset($normalized[$key]['unpublish_state']);
     }
 
     $event->setData($normalized);


### PR DESCRIPTION
Currently, when clients use content moderation, the first replication leads to unpublished nodes. The PR fixes this, but requires content moderation.